### PR TITLE
ADMIN PREPARE対策

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -305,7 +305,7 @@ func main() {
 	}
 
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local",
+		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local&interpolateParams=true",
 		user,
 		password,
 		host,


### PR DESCRIPTION
## 背景

`pt-query-digest /var/log/mysql/mysql-slow.log`

```
# Profile
# Rank Query ID           Response time Calls  R/Call V/M   Item
# ==== ================== ============= ====== ====== ===== ==============
#    1 0x99AA0165670CE848 95.2346 22.0%  98377 0.0010  0.00 ADMIN PREPARE
```

```
# Query 1: 870.59 QPS, 0.84x concurrency, ID 0x99AA0165670CE848 at byte 146087211
# Scores: V/M = 0.00
# Time range: 2022-07-13T06:30:27 to 2022-07-13T06:32:20
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count         33   98377
# Exec time     21     95s    32us    97ms   968us     3ms     1ms   541us
# Lock time      0       0       0       0       0       0       0       0
# Rows sent      0       0       0       0       0       0       0       0
# Rows examine   0       0       0       0       0       0       0       0
# Query size     2   2.81M      30      30      30      30       0      30
# String:
# Databases    isucari
# Hosts        localhost
# Users        isucari
# Query_time distribution
#   1us
#  10us  ###
# 100us  ################################################################
#   1ms  ############################
#  10ms  #
# 100ms  #
#    1s
#  10s+
administrator command: Prepare\G
```